### PR TITLE
Lazy load Joyride

### DIFF
--- a/client/app/bundles/Room/components/PageGuide.jsx
+++ b/client/app/bundles/Room/components/PageGuide.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import Joyride from 'react-joyride'
+import PropTypes from 'prop-types'
+
+export default class PageGuide extends React.Component {
+
+  static propTypes = {
+    callback: PropTypes.func,
+    isRunning: PropTypes.bool,
+    steps: PropTypes.array,
+    joyrideType: PropTypes.string
+  }
+
+  reset = () => {
+    this.joyride.reset()
+  }
+
+  next = () => {
+    this.joyride.next()
+  }
+
+  render() {
+    return (
+      <Joyride
+        ref={c => (this.joyride = c)}
+        callback={this.props.callback}
+        debug={false}
+        disableOverlay={true}
+        locale={{
+          back: (<span>Back</span>),
+          close: (<span>Close</span>),
+          last: (<span>Last</span>),
+          next: (<span>Next</span>),
+          skip: (<span>Skip</span>),
+        }}
+        run={this.props.isRunning}
+        showOverlay={true}
+        showSkipButton={true}
+        showStepsProgress={true}
+        steps={this.props.steps}
+        type={this.props.joyrideType}
+        autoStart={true}
+      />
+    )
+  }
+}

--- a/client/app/bundles/Room/containers/Room.jsx
+++ b/client/app/bundles/Room/containers/Room.jsx
@@ -9,7 +9,6 @@ import ActionBox from '../components/ActionBox/ActionBox'
 import Board from '../components/Board'
 import AirTraffic from 'libs/airTraffic'
 import update from 'immutability-helper'
-import Joyride from 'react-joyride'
 import EventEmitter from 'libs/eventEmitter'
 
 export default class Room extends React.Component {
@@ -88,7 +87,7 @@ export default class Room extends React.Component {
   }
 
   next() {
-    this.joyride.next()
+    this.pageGuide.next()
   }
 
   callback = (data) => {
@@ -105,7 +104,7 @@ export default class Room extends React.Component {
       })
 
       this.setState(newState)
-      this.joyride.reset()
+      this.pageGuide.reset()
     }
   }
 
@@ -119,6 +118,10 @@ export default class Room extends React.Component {
 
   componentDidMount() {
     EventEmitter.subscribe("roomClosed", this.handleNoStoryLeft)
+    import('../components/PageGuide').then(Component => {
+      this.PageGuide = Component
+      this.forceUpdate()
+    })
   }
 
   render() {
@@ -131,26 +134,16 @@ export default class Room extends React.Component {
 
     return (
       <div className="room" id="room">
-        <Joyride
-          ref={c => (this.joyride = c)}
-          callback={this.callback}
-          debug={false}
-          disableOverlay={true}
-          locale={{
-            back: (<span>Back</span>),
-            close: (<span>Close</span>),
-            last: (<span>Last</span>),
-            next: (<span>Next</span>),
-            skip: (<span>Skip</span>),
-          }}
-          run={isRunning}
-          showOverlay={true}
-          showSkipButton={true}
-          showStepsProgress={true}
-          steps={steps}
-          type={joyrideType}
-          autoStart={true}
-        />
+        {
+          this.PageGuide ?
+          <this.PageGuide.default
+            ref={c => (this.pageGuide = c)}
+            callback={this.callback}
+            isRunning={isRunning}
+            steps={steps}
+            joyrideType={joyrideType}
+            /> : null
+        }
         <StatusBar
           roomState={this.state.roomState}
           role={this.props.role}

--- a/client/webpack.config.base.js
+++ b/client/webpack.config.base.js
@@ -22,6 +22,7 @@ module.exports = {
 
   output: {
     filename: '[name]-[hash].js',
+    chunkFilename: '[name]-[hash].js',
     // Leading and trailing slashes ARE necessary.
     publicPath: '/' + webpackPublicOutputDir + '/',
     path: webpackOutputPath,


### PR DESCRIPTION
Fix #141 
From
```
Hash: 36d3ffc56c6851ceb6c7
Version: webpack 2.4.1
Time: 14211ms
                                    Asset       Size  Chunks                    Chunk Names
       app-bundle-36d3ffc56c6851ceb6c7.js    50.3 kB       0  [emitted]         app-bundle
    vendor-bundle-36d3ffc56c6851ceb6c7.js     363 kB       1  [emitted]  [big]  vendor-bundle
      app-bundle-36d3ffc56c6851ceb6c7.css  506 bytes       0  [emitted]         app-bundle
   app-bundle-36d3ffc56c6851ceb6c7.js.map  151 bytes       0  [emitted]         app-bundle
  app-bundle-36d3ffc56c6851ceb6c7.css.map  101 bytes       0  [emitted]         app-bundle
vendor-bundle-36d3ffc56c6851ceb6c7.js.map  157 bytes       1  [emitted]         vendor-bundle
                            manifest.json  384 bytes          [emitted]
```
To
```
Hash: 78d17295e32afbd7dc42
Version: webpack 2.4.1
Time: 15240ms
                                    Asset       Size  Chunks                    Chunk Names
                0-78d17295e32afbd7dc42.js    70.8 kB       0  [emitted]
       app-bundle-78d17295e32afbd7dc42.js    50.1 kB       1  [emitted]         app-bundle
    vendor-bundle-78d17295e32afbd7dc42.js     295 kB       2  [emitted]  [big]  vendor-bundle
      app-bundle-78d17295e32afbd7dc42.css  506 bytes       1  [emitted]         app-bundle
            0-78d17295e32afbd7dc42.js.map  133 bytes       0  [emitted]
   app-bundle-78d17295e32afbd7dc42.js.map  151 bytes       1  [emitted]         app-bundle
  app-bundle-78d17295e32afbd7dc42.css.map  101 bytes       1  [emitted]         app-bundle
vendor-bundle-78d17295e32afbd7dc42.js.map  157 bytes       2  [emitted]         vendor-bundle
                            manifest.json  512 bytes          [emitted]
```