### PR TITLE
Add related indexes to tables

### DIFF
--- a/db/migrate/20170821120103_add_index_to_user_rooms.rb
+++ b/db/migrate/20170821120103_add_index_to_user_rooms.rb
@@ -1,0 +1,5 @@
+class AddIndexToUserRooms < ActiveRecord::Migration[5.1]
+  def change
+    add_index :user_rooms, :room_id
+  end
+end

--- a/db/migrate/20170821120617_add_index_to_user_story_points.rb
+++ b/db/migrate/20170821120617_add_index_to_user_story_points.rb
@@ -1,0 +1,5 @@
+class AddIndexToUserStoryPoints < ActiveRecord::Migration[5.1]
+  def change
+    add_index :user_story_points, :story_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170728030255) do
+ActiveRecord::Schema.define(version: 20170821120103) do
 
   create_table "authorizations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 20170728030255) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "role"
+    t.index ["room_id"], name: "index_user_rooms_on_room_id"
     t.index ["user_id", "room_id"], name: "index_user_rooms_on_user_id_and_room_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170821120103) do
+ActiveRecord::Schema.define(version: 20170821120617) do
 
   create_table "authorizations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 20170821120103) do
     t.string "points"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["story_id"], name: "index_user_story_points_on_story_id"
     t.index ["user_id", "story_id"], name: "index_user_story_points_on_user_id_and_story_id", unique: true
   end
 


### PR DESCRIPTION
Seeing queries like
```
SELECT `stories`.* FROM `stories` INNER JOIN `user_story_points` ON `user_story_points`.`story_id` = `stories`.`id` WHERE (user_story_points.user_id = ?) AND (point IS NOT NULL) ORDER BY updated_at DESC LIMIT 10
```
Takes 14.7 ms to run

```
SELECT `rooms`.* FROM `rooms` INNER JOIN `user_rooms` ON `rooms`.`id` = `user_rooms`.`room_id` WHERE `user_rooms`.`user_id` = ? ORDER BY created_at DESC LIMIT 10 OFFSET ?
```
Takes 20.6 ms to run 