### PR TITLE
Use valid SPDX license expression to avoid yarn warning

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokrex",
   "version": "1.0.0",
-  "license": "GPL",
+  "license": "GPL-2.0",
   "author": "hlcfan",
   "scripts": {
     "postinstall": "npm rebuild node-sass",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3229,7 +3229,7 @@ react-joyride@^1.10.1:
     react-autobind "^1.0"
     scroll "^2.0"
 
-react-on-rails@9.0.3:
+react-on-rails@9.0.3, react-on-rails@^9.0.0-beta.12:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/react-on-rails/-/react-on-rails-9.0.3.tgz#da8a9873a94d62fe91e1f80d76716583f2be9da7"
   dependencies:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pokrex",
   "version": "0.0.1",
+  "license": "GPL-2.0",
   "private": true,
   "scripts": {
     "postinstall": "cd client && yarn install",


### PR DESCRIPTION
Fixes the warning from yarn

```
warning package.json: License should be a valid SPDX license expression
warning pokrex@1.0.0: License should be a valid SPDX license expression
```

Also updates yarn.lock in `client/`