### PR TITLE
Fix issue that fails to download room result as Excel file

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -200,11 +200,7 @@ class RoomsController < ApplicationController
   end
 
   def excel_filename
-    if @room.name.parameterize.blank?
-      @room.slug
-    else
-      @room.name
-    end
+    @room.slug[0..29]
   end
 
   def remove_memorization_of_moderators

--- a/app/views/rooms/show.xlsx.axlsx
+++ b/app/views/rooms/show.xlsx.axlsx
@@ -4,7 +4,7 @@ workbook.styles do |style|
 true, sz: 16)
   row_style = style.add_style(alignment: { horizontal: :left }, sz: 15)
 
-  workbook.add_worksheet(name: @room.name) do |sheet|
+  workbook.add_worksheet(name: "Estimation") do |sheet|
     total_point = 0
     sheet.add_row [room_url(@room.slug)], sz: 16
     sheet.add_hyperlink location: room_url(@room.slug), ref: sheet.rows.first.cells.first

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -56,15 +56,22 @@ RSpec.describe RoomsController, type: :controller do
       room = Room.create! valid_attributes
       story = room.stories.first
       get :show, params: {id: room.slug}, session: valid_session, format: :xlsx
-      expect(response.header["Content-Disposition"]).to eq("attachment; filename=room name.xlsx")
+      expect(response.header["Content-Disposition"]).to eq("attachment; filename=room-name.xlsx")
     end
 
-    it "returns Excel file which named by slug if room name being non-sense if request format is xlsx" do
-      room = Room.create! valid_attributes.merge(name: "...", slug: "slug-here")
-      room.update(slug: "slug-here")
+    it "returns Excel file with at most 30 chars as filename" do
+      room = Room.create! valid_attributes.merge(name: "...", slug: "slug-here-12345678909876543212345678900987654321")
+      room.update(slug: "slug-hereslug-here-12345678909876543212345678900987654321")
       story = room.stories.first
       get :show, params: {id: room.slug}, session: valid_session, format: :xlsx
-      expect(response.header["Content-Disposition"]).to eq("attachment; filename=slug-here.xlsx")
+      expect(response.header["Content-Disposition"]).to eq("attachment; filename=slug-hereslug-here-12345678909.xlsx")
+    end
+
+    it "returns Excel file with worksheet name equals 'Estimation'" do
+      room = Room.create! valid_attributes.merge(name: "2018/01/01")
+      story = room.stories.first
+      get :show, params: {id: room.slug}, session: valid_session, format: :xlsx
+      expect(response.header["Content-Disposition"]).to eq("attachment; filename=2018-01-01.xlsx")
     end
 
     it "redirects to room view page if moderator of async room" do


### PR DESCRIPTION
Fix #238 
It's because I was using room name as file name and worksheet name,
which in many cases could be invalid, like:
```
Your worksheet name 'Refinement 01/10/2018' contains a character which is not allowed by MS Excel and will cause repair warnings. Please change the name of your sheet
```

Another issue is some room name could be pretty long, and worksheet name can only allow length of 31, like
```
Your worksheet name 'BAPRO - PSR - Sprint 3 - 12/10/2018' is too long. Worksheet names must be 31 characters (bytes) or less
```

Hell, I should've fixed those earlier.